### PR TITLE
Add AI agent posture drift comparison checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,14 @@ Click **Sign In** on either page — a demo JWT is minted automatically, no acco
 | **Multi-Model Support** | Swap between Claude Haiku, Sonnet, Opus via `ANTHROPIC_MODEL` env var. Architecture supports any OpenAI-compatible endpoint. | CPM API |
 | **Model Freeze** | Freeze controller suspends a model from serving traffic in real time via Kafka `freeze_control` topic. | Freeze Controller |
 
+### Agent Posture Drift
+
+| Feature | Description | Component |
+|---|---|---|
+| **Baseline vs Current Comparison** | Compares approved agent posture snapshots with current runtime state to detect model, tool, identity, runtime, RAG, and guardrail drift. | `platform_shared.posture_drift` |
+| **Risk-Based Reapproval** | Classifies drift as low, medium, high, or critical and recommends accept, re-review, rollback, or disable actions. | SPM API / Agent Control Plane |
+| **Evidence Hashing** | Produces stable evidence hashes for audit records and compliance reporting. | Audit / Compliance |
+
 ### Agentic Tools
 
 | Feature | Description | Component |

--- a/docs/posture-drift-checks.md
+++ b/docs/posture-drift-checks.md
@@ -1,0 +1,98 @@
+# AI Agent Posture Drift Checks
+
+AI-SPM needs to know when an approved agent, model route, tool surface, or RAG
+source has moved outside the security boundary that was reviewed at onboarding.
+Posture drift checks compare a baseline snapshot with the current observed
+runtime state and produce deterministic findings that can be routed to an owner,
+review queue, or policy gate.
+
+## Snapshot Inputs
+
+The comparison engine accepts dictionaries so it can be used by API routes,
+database jobs, CI fixtures, or runtime observers without a database dependency.
+A posture snapshot can include these sections:
+
+| Section | Example fields | Why it matters |
+| --- | --- | --- |
+| `model` | provider, name, version, route, risk tier, retention mode, logging mode, region | Detects provider/model/region/logging changes after approval. |
+| `tools` | name, category, schema hash, endpoint, command, capabilities, approval requirement | Detects new MCP tools, side-effect tools, endpoint changes, and schema drift. |
+| `identity` | OAuth scopes, token audience, service account, token lifetime | Detects broader authorization or delegated token changes. |
+| `runtime` | shell access, browser profile access, container socket, privileged mode, network egress, mounts | Detects escape-prone runtime boundary changes. |
+| `rag_sources` or `memory.sources` | source name, approved flag, classification, index version, embedding model, trust score | Detects unapproved or high-sensitivity retrieval sources. |
+| `guardrails` | policy bundle hash, prompt/output/tool policy versions, thresholds, approval settings | Detects policy weakening or unreviewed guardrail changes. |
+
+## Output Finding Shape
+
+Each finding includes:
+
+| Field | Purpose |
+| --- | --- |
+| `baseline_id` | Approved posture snapshot being compared against. |
+| `current_snapshot_id` | Current scan or observed runtime snapshot. |
+| `drift_type` | `model`, `tool`, `identity`, `runtime`, `memory`, `guardrail`, `provider`, or `network`. |
+| `changed_fields` | Bounded list of fields that moved from the baseline. |
+| `risk_level` | `low`, `medium`, `high`, or `critical`. |
+| `approval_required` | Whether owner/security re-approval is required. |
+| `evidence_hash` | Stable hash of the compared evidence package. |
+| `owner` | Accountable team or service owner. |
+| `recommended_action` | `record_as_accepted_change`, `route_to_owner_for_reapproval`, `require_security_review_before_continued_operation`, or `disable_or_rollback_until_reapproved`. |
+
+## Severity Guidance
+
+| Drift signal | Default severity | Rationale |
+| --- | --- | --- |
+| Provider/model route, retention mode, logging mode, or fallback route changed | High | The data path and privacy/compliance boundary may have changed. |
+| New write, shell, browser, deployment, database, email, Kubernetes, or filesystem tool | High | Side-effect tools can modify data, send messages, or widen blast radius. |
+| Wildcard or administrator OAuth scope added | Critical | The agent can now act outside the approved authorization boundary. |
+| Container socket, privileged runtime, host mount, or Docker socket access | Critical | These changes can collapse workload isolation. |
+| External or wildcard network egress added | High | The agent can now reach a broader destination set. |
+| Unapproved or restricted RAG source added | High | Context can introduce sensitive data or untrusted instructions. |
+| Side-effect approval disabled | Critical | The human-in-the-loop safety boundary was weakened. |
+
+## Example
+
+```python
+from platform_shared.posture_drift import compare_posture_snapshots
+
+baseline = {
+    "snapshot_id": "approved-2026-05-01",
+    "owner": "ai-platform",
+    "tools": [{"name": "security.review", "category": "read"}],
+    "identity": {"scopes": ["agent:read"]},
+}
+
+current = {
+    "snapshot_id": "scan-2026-05-09",
+    "owner": "ai-platform",
+    "tools": [
+        {"name": "security.review", "category": "read"},
+        {"name": "file.write", "category": "write", "approval_required": True},
+    ],
+    "identity": {"scopes": ["agent:read", "admin:*"]},
+}
+
+report = compare_posture_snapshots(baseline, current)
+assert report.approval_required is True
+```
+
+The report can be persisted as compliance evidence, attached to an agent
+inventory row, or used by a policy gate before an agent continues operation.
+
+## Recommended Remediation Flow
+
+1. For `low` findings, record the change as accepted operational drift.
+2. For `medium` findings, route the change to the system owner for re-approval.
+3. For `high` findings, require security review before continued operation.
+4. For `critical` findings, disable, roll back, or freeze the affected agent until it is re-approved.
+
+## Integration Path
+
+The shared comparison engine is intentionally independent of FastAPI, SQLAlchemy,
+Kafka, and Kubernetes. Suggested follow-up integrations:
+
+1. Generate baseline snapshots when an agent or model route is approved.
+2. Generate current snapshots from agent runtime metadata, MCP manifests, identity
+   scopes, policy bundle hashes, and RAG source metadata.
+3. Store `DriftReport` output as audit evidence and surface high/critical drift in
+   the admin portal.
+4. Add a policy gate that blocks or freezes agents when critical drift is detected.

--- a/platform_shared/posture_drift.py
+++ b/platform_shared/posture_drift.py
@@ -1,0 +1,641 @@
+"""Agent posture drift comparison primitives.
+
+The functions in this module compare an approved baseline snapshot with a
+current runtime snapshot and return deterministic findings that other services
+can persist, render, or turn into approval gates.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from hashlib import sha256
+import json
+from typing import Any, Iterable, Literal, Mapping
+
+
+RiskLevel = Literal["low", "medium", "high", "critical"]
+DriftType = Literal[
+    "model",
+    "tool",
+    "identity",
+    "runtime",
+    "memory",
+    "network",
+    "guardrail",
+    "provider",
+]
+
+_RISK_RANK: dict[str, int] = {
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+    "critical": 4,
+}
+
+_SENSITIVE_SCOPE_HINTS = (
+    "*",
+    "admin",
+    "delete",
+    "impersonate",
+    "root",
+    "secret",
+    "send",
+    "token",
+    "write",
+)
+
+_HIGH_RISK_TOOL_HINTS = (
+    "browser",
+    "container",
+    "db",
+    "delete",
+    "deploy",
+    "email",
+    "exec",
+    "file.write",
+    "filesystem",
+    "kubernetes",
+    "shell",
+    "write",
+)
+
+
+@dataclass(frozen=True)
+class DriftFinding:
+    """Single posture-drift finding."""
+
+    baseline_id: str
+    current_snapshot_id: str
+    drift_type: DriftType
+    changed_fields: list[str]
+    risk_level: RiskLevel
+    approval_required: bool
+    evidence_hash: str
+    owner: str
+    summary: str
+    recommended_action: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DriftReport:
+    """Aggregate comparison result for one baseline/current pair."""
+
+    baseline_id: str
+    current_snapshot_id: str
+    risk_level: RiskLevel
+    approval_required: bool
+    findings: list[DriftFinding]
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["findings"] = [finding.to_dict() for finding in self.findings]
+        return data
+
+
+def compare_posture_snapshots(
+    baseline: Mapping[str, Any],
+    current: Mapping[str, Any],
+    *,
+    owner: str | None = None,
+) -> DriftReport:
+    """Compare two agent posture snapshots.
+
+    Parameters
+    ----------
+    baseline:
+        Previously approved posture snapshot.
+    current:
+        Freshly observed runtime snapshot.
+    owner:
+        Optional owning team or service name. When omitted, the value is
+        inferred from the snapshots and falls back to ``"unknown"``.
+    """
+
+    baseline_id = _snapshot_id(baseline, "baseline")
+    current_id = _snapshot_id(current, "current")
+    finding_owner = (
+        owner
+        or _string_or_none(current.get("owner"))
+        or _string_or_none(baseline.get("owner"))
+        or "unknown"
+    )
+
+    findings: list[DriftFinding] = []
+    findings.extend(_compare_model_route(baseline, current, baseline_id, current_id, finding_owner))
+    findings.extend(_compare_tools(baseline, current, baseline_id, current_id, finding_owner))
+    findings.extend(_compare_identity(baseline, current, baseline_id, current_id, finding_owner))
+    findings.extend(_compare_runtime(baseline, current, baseline_id, current_id, finding_owner))
+    findings.extend(_compare_memory_sources(baseline, current, baseline_id, current_id, finding_owner))
+    findings.extend(_compare_guardrails(baseline, current, baseline_id, current_id, finding_owner))
+
+    risk_level = _max_risk([finding.risk_level for finding in findings])
+    return DriftReport(
+        baseline_id=baseline_id,
+        current_snapshot_id=current_id,
+        risk_level=risk_level,
+        approval_required=any(finding.approval_required for finding in findings),
+        findings=findings,
+    )
+
+
+def _compare_model_route(
+    baseline: Mapping[str, Any],
+    current: Mapping[str, Any],
+    baseline_id: str,
+    current_id: str,
+    owner: str,
+) -> list[DriftFinding]:
+    fields = (
+        "model_id",
+        "model.provider",
+        "model.name",
+        "model.version",
+        "model.route",
+        "model.risk_tier",
+        "model.retention_mode",
+        "model.logging_mode",
+        "model.region",
+        "provider",
+        "provider_route",
+        "fallback_providers",
+    )
+    changed = _changed_paths(baseline, current, fields)
+    if not changed:
+        return []
+
+    risk = "high" if any(_is_sensitive_model_field(path) for path in changed) else "medium"
+    return [
+        _finding(
+            baseline_id,
+            current_id,
+            "model",
+            changed,
+            risk,
+            "Model or provider route changed from the approved posture baseline.",
+            owner,
+        )
+    ]
+
+
+def _compare_tools(
+    baseline: Mapping[str, Any],
+    current: Mapping[str, Any],
+    baseline_id: str,
+    current_id: str,
+    owner: str,
+) -> list[DriftFinding]:
+    baseline_tools = _index_named(_collect_items(baseline, "tools", "mcp.tools", "agent.tools"))
+    current_tools = _index_named(_collect_items(current, "tools", "mcp.tools", "agent.tools"))
+
+    changed: list[str] = []
+    risk_levels: list[RiskLevel] = []
+    for name in sorted(current_tools.keys() - baseline_tools.keys()):
+        changed.append(f"tools.{name}:added")
+        risk_levels.append(_tool_risk(current_tools[name]))
+
+    for name in sorted(baseline_tools.keys() - current_tools.keys()):
+        changed.append(f"tools.{name}:removed")
+        risk_levels.append("low")
+
+    watched_fields = (
+        "description",
+        "schema_hash",
+        "command",
+        "endpoint",
+        "package_version",
+        "capabilities",
+        "category",
+        "side_effect",
+        "approval_required",
+    )
+    for name in sorted(baseline_tools.keys() & current_tools.keys()):
+        for field in watched_fields:
+            if _canonical(baseline_tools[name].get(field)) != _canonical(current_tools[name].get(field)):
+                changed.append(f"tools.{name}.{field}")
+                risk_levels.append(_changed_tool_field_risk(field, current_tools[name].get(field)))
+
+    if not changed:
+        return []
+
+    return [
+        _finding(
+            baseline_id,
+            current_id,
+            "tool",
+            changed,
+            _max_risk(risk_levels),
+            "MCP or agent tool surface changed after approval.",
+            owner,
+        )
+    ]
+
+
+def _compare_identity(
+    baseline: Mapping[str, Any],
+    current: Mapping[str, Any],
+    baseline_id: str,
+    current_id: str,
+    owner: str,
+) -> list[DriftFinding]:
+    baseline_scopes = _scope_set(baseline)
+    current_scopes = _scope_set(current)
+    added_scopes = sorted(current_scopes - baseline_scopes)
+    removed_scopes = sorted(baseline_scopes - current_scopes)
+
+    changed = [f"identity.scopes.+{scope}" for scope in added_scopes]
+    changed.extend(f"identity.scopes.-{scope}" for scope in removed_scopes)
+    changed.extend(
+        _changed_paths(
+            baseline,
+            current,
+            (
+                "identity.token_audience",
+                "identity.token_lifetime_minutes",
+                "identity.service_account",
+                "service_account",
+            ),
+        )
+    )
+
+    if not changed:
+        return []
+
+    risk: RiskLevel = "medium"
+    if any(_looks_sensitive_scope(scope) for scope in added_scopes):
+        risk = "high"
+    if any(scope == "*" or scope.endswith(":*") for scope in added_scopes):
+        risk = "critical"
+
+    return [
+        _finding(
+            baseline_id,
+            current_id,
+            "identity",
+            changed,
+            risk,
+            "Identity, token, or authorization scope changed from the approved baseline.",
+            owner,
+        )
+    ]
+
+
+def _compare_runtime(
+    baseline: Mapping[str, Any],
+    current: Mapping[str, Any],
+    baseline_id: str,
+    current_id: str,
+    owner: str,
+) -> list[DriftFinding]:
+    changed = _changed_paths(
+        baseline,
+        current,
+        (
+            "runtime.shell_access",
+            "runtime.browser_profile_access",
+            "runtime.container_socket_access",
+            "runtime.privileged",
+            "runtime.filesystem_mounts",
+            "runtime.env_secret_refs",
+            "runtime.network_egress",
+            "network_egress",
+            "filesystem_mounts",
+        ),
+    )
+    if not changed:
+        return []
+
+    runtime = _as_mapping(current.get("runtime"))
+    risk: RiskLevel = "medium"
+    if (
+        runtime.get("shell_access") is True
+        or runtime.get("browser_profile_access") is True
+        or _new_network_egress_is_external(baseline, current)
+    ):
+        risk = "high"
+    if runtime.get("container_socket_access") is True or runtime.get("privileged") is True:
+        risk = "critical"
+    if _has_critical_mount(current):
+        risk = "critical"
+
+    return [
+        _finding(
+            baseline_id,
+            current_id,
+            "runtime",
+            changed,
+            risk,
+            "Runtime boundary changed from the approved execution posture.",
+            owner,
+        )
+    ]
+
+
+def _compare_memory_sources(
+    baseline: Mapping[str, Any],
+    current: Mapping[str, Any],
+    baseline_id: str,
+    current_id: str,
+    owner: str,
+) -> list[DriftFinding]:
+    baseline_sources = _index_named(_collect_items(baseline, "rag_sources", "memory.sources", "rag.sources"))
+    current_sources = _index_named(_collect_items(current, "rag_sources", "memory.sources", "rag.sources"))
+
+    changed: list[str] = []
+    risk_levels: list[RiskLevel] = []
+
+    for name in sorted(current_sources.keys() - baseline_sources.keys()):
+        changed.append(f"memory.sources.{name}:added")
+        risk_levels.append(_source_risk(current_sources[name]))
+
+    for name in sorted(baseline_sources.keys() - current_sources.keys()):
+        changed.append(f"memory.sources.{name}:removed")
+        risk_levels.append("low")
+
+    for name in sorted(baseline_sources.keys() & current_sources.keys()):
+        for field in ("approved", "classification", "index_version", "embedding_model", "trust_score"):
+            if _canonical(baseline_sources[name].get(field)) != _canonical(current_sources[name].get(field)):
+                changed.append(f"memory.sources.{name}.{field}")
+                risk_levels.append("high" if field == "approved" and not current_sources[name].get(field) else "medium")
+
+    if not changed:
+        return []
+
+    return [
+        _finding(
+            baseline_id,
+            current_id,
+            "memory",
+            changed,
+            _max_risk(risk_levels),
+            "RAG or memory source posture changed from the approved baseline.",
+            owner,
+        )
+    ]
+
+
+def _compare_guardrails(
+    baseline: Mapping[str, Any],
+    current: Mapping[str, Any],
+    baseline_id: str,
+    current_id: str,
+    owner: str,
+) -> list[DriftFinding]:
+    changed = _changed_paths(
+        baseline,
+        current,
+        (
+            "guardrails.policy_bundle_hash",
+            "guardrails.prompt_policy_version",
+            "guardrails.output_policy_version",
+            "guardrails.tool_policy_version",
+            "guardrails.memory_policy_version",
+            "guardrails.decision_thresholds",
+            "guardrails.approval_required_for_side_effects",
+            "policy_bundle_hash",
+        ),
+    )
+    if not changed:
+        return []
+
+    risk: RiskLevel = "high"
+    if "guardrails.approval_required_for_side_effects" in changed:
+        current_guardrails = _as_mapping(current.get("guardrails"))
+        if current_guardrails.get("approval_required_for_side_effects") is False:
+            risk = "critical"
+
+    return [
+        _finding(
+            baseline_id,
+            current_id,
+            "guardrail",
+            changed,
+            risk,
+            "Guardrail or policy bundle changed after posture approval.",
+            owner,
+        )
+    ]
+
+
+def _finding(
+    baseline_id: str,
+    current_id: str,
+    drift_type: DriftType,
+    changed_fields: list[str],
+    risk_level: RiskLevel,
+    summary: str,
+    owner: str,
+) -> DriftFinding:
+    approval_required = risk_level in {"medium", "high", "critical"}
+    recommended_action = _recommended_action(risk_level)
+    evidence = _evidence_hash(
+        {
+            "baseline_id": baseline_id,
+            "current_snapshot_id": current_id,
+            "drift_type": drift_type,
+            "changed_fields": changed_fields,
+            "risk_level": risk_level,
+        }
+    )
+    return DriftFinding(
+        baseline_id=baseline_id,
+        current_snapshot_id=current_id,
+        drift_type=drift_type,
+        changed_fields=changed_fields,
+        risk_level=risk_level,
+        approval_required=approval_required,
+        evidence_hash=evidence,
+        owner=owner,
+        summary=summary,
+        recommended_action=recommended_action,
+    )
+
+
+def _recommended_action(risk_level: RiskLevel) -> str:
+    if risk_level == "critical":
+        return "disable_or_rollback_until_reapproved"
+    if risk_level == "high":
+        return "require_security_review_before_continued_operation"
+    if risk_level == "medium":
+        return "route_to_owner_for_reapproval"
+    return "record_as_accepted_change"
+
+
+def _snapshot_id(snapshot: Mapping[str, Any], fallback: str) -> str:
+    value = snapshot.get("snapshot_id") or snapshot.get("id") or fallback
+    return str(value)
+
+
+def _string_or_none(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value
+    return None
+
+
+def _changed_paths(
+    baseline: Mapping[str, Any],
+    current: Mapping[str, Any],
+    paths: Iterable[str],
+) -> list[str]:
+    changed: list[str] = []
+    for path in paths:
+        if _canonical(_get_path(baseline, path)) != _canonical(_get_path(current, path)):
+            changed.append(path)
+    return changed
+
+
+def _get_path(data: Mapping[str, Any], path: str) -> Any:
+    value: Any = data
+    for part in path.split("."):
+        if not isinstance(value, Mapping):
+            return None
+        value = value.get(part)
+    return value
+
+
+def _canonical(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _canonical(value[key]) for key in sorted(value)}
+    if isinstance(value, set):
+        return sorted(_canonical(item) for item in value)
+    if isinstance(value, (list, tuple)):
+        return [_canonical(item) for item in value]
+    return value
+
+
+def _evidence_hash(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(_canonical(payload), sort_keys=True, separators=(",", ":"))
+    return sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _max_risk(levels: Iterable[str]) -> RiskLevel:
+    ordered = list(levels)
+    if not ordered:
+        return "low"
+    return max(ordered, key=lambda level: _RISK_RANK.get(level, 0))  # type: ignore[return-value]
+
+
+def _collect_items(snapshot: Mapping[str, Any], *paths: str) -> list[Any]:
+    for path in paths:
+        items = _get_path(snapshot, path)
+        if items:
+            if isinstance(items, Mapping):
+                return [{"name": key, **_as_mapping(value)} for key, value in items.items()]
+            if isinstance(items, list):
+                return items
+    return []
+
+
+def _index_named(items: list[Any]) -> dict[str, dict[str, Any]]:
+    indexed: dict[str, dict[str, Any]] = {}
+    for item in items:
+        if isinstance(item, str):
+            indexed[item] = {"name": item}
+            continue
+        data = _as_mapping(item)
+        name = data.get("name") or data.get("id") or data.get("source") or data.get("tool_name")
+        if name:
+            indexed[str(name)] = data
+    return indexed
+
+
+def _as_mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
+def _scope_set(snapshot: Mapping[str, Any]) -> set[str]:
+    values: list[Any] = []
+    for path in ("identity.scopes", "auth_context.scopes", "oauth_scopes", "service_account.scopes"):
+        item = _get_path(snapshot, path)
+        if isinstance(item, list):
+            values.extend(item)
+        elif isinstance(item, str):
+            values.append(item)
+    return {str(value) for value in values}
+
+
+def _looks_sensitive_scope(scope: str) -> bool:
+    lower = scope.lower()
+    return any(hint in lower for hint in _SENSITIVE_SCOPE_HINTS)
+
+
+def _tool_risk(tool: Mapping[str, Any]) -> RiskLevel:
+    text = " ".join(str(value).lower() for value in tool.values())
+    if "container socket" in text or "docker.sock" in text:
+        return "critical"
+    if any(hint in text for hint in _HIGH_RISK_TOOL_HINTS):
+        return "high"
+    return "medium"
+
+
+def _changed_tool_field_risk(field: str, value: Any) -> RiskLevel:
+    if field == "approval_required" and value is False:
+        return "high"
+    if field in {"command", "endpoint", "capabilities", "side_effect"}:
+        return "high"
+    if field == "category" and _tool_risk({"category": value}) == "high":
+        return "high"
+    return "medium"
+
+
+def _source_risk(source: Mapping[str, Any]) -> RiskLevel:
+    if source.get("approved") is False:
+        return "high"
+    classification = str(source.get("classification") or "").lower()
+    if classification in {"restricted", "secret", "confidential"}:
+        return "high"
+    if str(source.get("owner") or "").lower() in {"external", "third-party", "untrusted"}:
+        return "high"
+    return "medium"
+
+
+def _is_sensitive_model_field(path: str) -> bool:
+    return path in {
+        "model.provider",
+        "model.name",
+        "model.route",
+        "model.risk_tier",
+        "model.retention_mode",
+        "model.logging_mode",
+        "provider",
+        "provider_route",
+        "fallback_providers",
+    }
+
+
+def _new_network_egress_is_external(
+    baseline: Mapping[str, Any],
+    current: Mapping[str, Any],
+) -> bool:
+    baseline_egress = _egress_set(baseline)
+    current_egress = _egress_set(current)
+    added = current_egress - baseline_egress
+    return any(target in {"*", "0.0.0.0/0", "internet"} or "." in target for target in added)
+
+
+def _egress_set(snapshot: Mapping[str, Any]) -> set[str]:
+    values: list[Any] = []
+    for path in ("runtime.network_egress", "network_egress"):
+        item = _get_path(snapshot, path)
+        if isinstance(item, list):
+            values.extend(item)
+        elif isinstance(item, str):
+            values.append(item)
+    return {str(value).lower() for value in values}
+
+
+def _has_critical_mount(snapshot: Mapping[str, Any]) -> bool:
+    mounts: list[Any] = []
+    for path in ("runtime.filesystem_mounts", "filesystem_mounts"):
+        item = _get_path(snapshot, path)
+        if isinstance(item, list):
+            mounts.extend(item)
+    for mount in mounts:
+        data = _as_mapping(mount)
+        target = str(data.get("path") or data.get("mount") or mount).lower()
+        if target in {"/", "/host", "/var/run/docker.sock"} or "docker.sock" in target:
+            return True
+    return False

--- a/tests/test_posture_drift.py
+++ b/tests/test_posture_drift.py
@@ -1,0 +1,173 @@
+from platform_shared.posture_drift import compare_posture_snapshots
+
+
+def _baseline():
+    return {
+        "snapshot_id": "base-001",
+        "owner": "ai-platform",
+        "model": {
+            "provider": "anthropic",
+            "name": "claude-sonnet",
+            "version": "2026-04",
+            "route": "primary",
+            "retention_mode": "zero-retention",
+            "logging_mode": "metadata-only",
+            "region": "eu",
+        },
+        "tools": [
+            {
+                "name": "security.review",
+                "category": "read",
+                "schema_hash": "schema-a",
+                "approval_required": False,
+            }
+        ],
+        "identity": {
+            "scopes": ["agent:read"],
+            "token_audience": "aispm",
+            "token_lifetime_minutes": 30,
+        },
+        "runtime": {
+            "shell_access": False,
+            "browser_profile_access": False,
+            "container_socket_access": False,
+            "privileged": False,
+            "network_egress": ["spm-api.aispm.svc.cluster.local"],
+            "filesystem_mounts": [{"path": "/tmp"}],
+        },
+        "rag_sources": [
+            {
+                "name": "approved-security-playbooks",
+                "approved": True,
+                "classification": "internal",
+                "index_version": "v1",
+                "embedding_model": "text-embedding-3-small",
+                "trust_score": 0.9,
+            }
+        ],
+        "guardrails": {
+            "policy_bundle_hash": "policy-a",
+            "approval_required_for_side_effects": True,
+            "decision_thresholds": {"block": 0.7, "escalate": 0.3},
+        },
+    }
+
+
+def test_unchanged_posture_has_no_findings():
+    report = compare_posture_snapshots(_baseline(), _baseline())
+
+    assert report.risk_level == "low"
+    assert report.approval_required is False
+    assert report.findings == []
+
+
+def test_model_route_change_requires_review():
+    current = _baseline()
+    current["snapshot_id"] = "cur-001"
+    current["model"] = {**current["model"], "provider": "openai"}
+
+    report = compare_posture_snapshots(_baseline(), current)
+
+    assert report.risk_level == "high"
+    assert report.approval_required is True
+    assert report.findings[0].drift_type == "model"
+    assert "model.provider" in report.findings[0].changed_fields
+
+
+def test_new_write_tool_is_high_risk():
+    current = _baseline()
+    current["snapshot_id"] = "cur-002"
+    current["tools"] = [
+        *current["tools"],
+        {
+            "name": "file.write",
+            "category": "write",
+            "command": "write_file",
+            "approval_required": True,
+        },
+    ]
+
+    report = compare_posture_snapshots(_baseline(), current)
+    finding = report.findings[0]
+
+    assert finding.drift_type == "tool"
+    assert finding.risk_level == "high"
+    assert "tools.file.write:added" in finding.changed_fields
+
+
+def test_wildcard_identity_scope_is_critical():
+    current = _baseline()
+    current["snapshot_id"] = "cur-003"
+    current["identity"] = {**current["identity"], "scopes": ["agent:read", "admin:*"]}
+
+    report = compare_posture_snapshots(_baseline(), current)
+    finding = next(item for item in report.findings if item.drift_type == "identity")
+
+    assert finding.risk_level == "critical"
+    assert finding.recommended_action == "disable_or_rollback_until_reapproved"
+    assert "identity.scopes.+admin:*" in finding.changed_fields
+
+
+def test_runtime_container_socket_mount_is_critical():
+    current = _baseline()
+    current["snapshot_id"] = "cur-004"
+    current["runtime"] = {
+        **current["runtime"],
+        "container_socket_access": True,
+        "filesystem_mounts": [{"path": "/var/run/docker.sock"}],
+    }
+
+    report = compare_posture_snapshots(_baseline(), current)
+    finding = next(item for item in report.findings if item.drift_type == "runtime")
+
+    assert finding.risk_level == "critical"
+    assert "runtime.container_socket_access" in finding.changed_fields
+    assert "runtime.filesystem_mounts" in finding.changed_fields
+
+
+def test_unapproved_rag_source_requires_security_review():
+    current = _baseline()
+    current["snapshot_id"] = "cur-005"
+    current["rag_sources"] = [
+        *current["rag_sources"],
+        {
+            "name": "team-drive-dump",
+            "approved": False,
+            "classification": "confidential",
+            "index_version": "v1",
+        },
+    ]
+
+    report = compare_posture_snapshots(_baseline(), current)
+    finding = next(item for item in report.findings if item.drift_type == "memory")
+
+    assert finding.risk_level == "high"
+    assert "memory.sources.team-drive-dump:added" in finding.changed_fields
+    assert finding.approval_required is True
+
+
+def test_policy_bundle_approval_disabled_is_critical():
+    current = _baseline()
+    current["snapshot_id"] = "cur-006"
+    current["guardrails"] = {
+        **current["guardrails"],
+        "policy_bundle_hash": "policy-b",
+        "approval_required_for_side_effects": False,
+    }
+
+    report = compare_posture_snapshots(_baseline(), current)
+    finding = next(item for item in report.findings if item.drift_type == "guardrail")
+
+    assert finding.risk_level == "critical"
+    assert "guardrails.policy_bundle_hash" in finding.changed_fields
+    assert "guardrails.approval_required_for_side_effects" in finding.changed_fields
+
+
+def test_evidence_hash_is_stable_for_same_change():
+    current = _baseline()
+    current["model"] = {**current["model"], "provider": "openai"}
+
+    first = compare_posture_snapshots(_baseline(), current)
+    second = compare_posture_snapshots(_baseline(), current)
+
+    assert first.findings[0].evidence_hash == second.findings[0].evidence_hash


### PR DESCRIPTION
## Summary
- add a deterministic posture drift comparison engine for approved baseline vs current AI agent/runtime snapshots
- classify model route, MCP/tool, identity scope, runtime boundary, RAG/memory source, and guardrail drift with risk levels, evidence hashes, owner routing, and remediation guidance
- document snapshot inputs, severity guidance, output fields, example usage, and integration path

## Validation
- `pytest tests/test_posture_drift.py -q` -> 8 passed
- `python -m compileall platform_shared/posture_drift.py tests/test_posture_drift.py`

Refs #27