### PR TITLE
fix(orch): coerce UUID session_id to str + re-export _decode_token

### DIFF
--- a/services/agent-orchestrator-service/dependencies/auth.py
+++ b/services/agent-orchestrator-service/dependencies/auth.py
@@ -6,5 +6,6 @@ Import from here or from platform_shared.rbac; both work.
 """
 from platform_shared.rbac import (  # noqa: F401  re-exported
     IdentityContext,
+    _decode_token,
     get_current_identity,
 )

--- a/services/agent-orchestrator-service/schemas/events.py
+++ b/services/agent-orchestrator-service/schemas/events.py
@@ -21,7 +21,7 @@ from enum import Enum
 from typing import Any, ClassVar, Dict, FrozenSet, List, Optional
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -127,6 +127,8 @@ class SessionLifecycleEvent(BaseModel):
     event_type:     EventType
     # session_id is a free-form string -- the chat sessions use IDs like
     # "session-1778614829220" and "agent-<uuid>-runtime" which are not UUIDs.
+    # Pydantic v2 rejects UUID for a str field under default strict-ish mode,
+    # but lifecycle event emission upstream passes a UUID, so coerce here.
     session_id:     str
     correlation_id: str            = Field(..., description="Shared trace ID across all steps")
     timestamp:      datetime       = Field(default_factory=_utcnow)
@@ -134,6 +136,11 @@ class SessionLifecycleEvent(BaseModel):
     status:         str            = Field(..., description="Outcome of this step, e.g. ok / blocked / scored")
     summary:        str            = Field(..., description="Human-readable one-liner for timeline display")
     payload:        Dict[str, Any] = Field(default_factory=dict, description="Full step-specific data")
+
+    @field_validator("session_id", mode="before")
+    @classmethod
+    def _coerce_session_id_to_str(cls, v: Any) -> Any:
+        return str(v) if isinstance(v, UUID) else v
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -276,6 +283,11 @@ class SessionEventListResponse(BaseModel):
     correlation_id: str
     event_count:    int
     events:         List[SessionLifecycleEvent]
+
+    @field_validator("session_id", mode="before")
+    @classmethod
+    def _coerce_session_id_to_str(cls, v: Any) -> Any:
+        return str(v) if isinstance(v, UUID) else v
 
 
 class SessionTimelineEntry(BaseModel):


### PR DESCRIPTION
## Summary

Two CI failures introduced by the RBAC merge (PR #37):

- `SessionLifecycleEvent.session_id` was switched from `UUID` to `str` for the API response model, but `EventPublisher._emit()` passes `UUID`. Pydantic v2 rejects that at construction time, breaking ~22 orchestrator tests. Added a `@field_validator(mode="before")` that coerces `UUID` → `str` on both `SessionLifecycleEvent` and `SessionEventListResponse`.
- `tests/test_auth_deps.py` imports `_decode_token` from `dependencies.auth`, but the shim was reduced to re-exporting `IdentityContext` + `get_current_identity` only. Re-export `_decode_token` so the JWT-signature regression test compiles.

## Test plan

- [x] `pytest tests/` — 529 passed
- [x] `pytest services/api/tests/` — 193 passed
- [x] `pytest services/agent-orchestrator-service/tests/` — 383 passed (was 358 passed / 25 failed before the fix)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Pp147sgmYk83YZEvaqStp)_